### PR TITLE
Task: Write-acess code refactor and update Documentation with Fan write-access

### DIFF
--- a/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
+++ b/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
@@ -321,6 +321,81 @@ The driver supports all Home Assistant cover types including: awning, blind, cur
 
    Check your specific device's capabilities in the Home Assistant Developer Tools > States panel.
 
+Example Fan Registry
+***************************
+
+Fans are multi-function devices that can be controlled via:
+
+- **state**: 0 = off, 1 = on
+- **percentage**: 0-100, speed level
+- **preset_mode**: device-specific presets (e.g., auto, sleep, nature)
+- **direction**: forward / reverse
+- **oscillating**: 0 = off, 1 = on (or False/True)
+
+.. code-block:: json
+
+   [
+       {
+           "Entity ID": "fan.living_room_fan",
+           "Entity Point": "state",
+           "Volttron Point Name": "fan_state",
+           "Units": "On / Off",
+           "Units Details": "off: 0, on: 1",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Power on/off"
+       },
+       {
+           "Entity ID": "fan.living_room_fan",
+           "Entity Point": "percentage",
+           "Volttron Point Name": "fan_speed",
+           "Units": "%",
+           "Units Details": "0-100",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Speed percentage"
+       },
+       {
+           "Entity ID": "fan.living_room_fan",
+           "Entity Point": "preset_mode",
+           "Volttron Point Name": "fan_preset",
+           "Units": "Preset",
+           "Units Details": "device-specific (e.g., auto, sleep)",
+           "Writable": true,
+           "Starting Value": "",
+           "Type": "string",
+           "Notes": "Preset mode"
+       },
+       {
+           "Entity ID": "fan.living_room_fan",
+           "Entity Point": "direction",
+           "Volttron Point Name": "fan_direction",
+           "Units": "Direction",
+           "Units Details": "forward, reverse",
+           "Writable": true,
+           "Starting Value": "forward",
+           "Type": "string",
+           "Notes": "Rotation direction"
+       },
+       {
+           "Entity ID": "fan.living_room_fan",
+           "Entity Point": "oscillating",
+           "Volttron Point Name": "fan_oscillating",
+           "Units": "On / Off",
+           "Units Details": "off: 0, on: 1",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Oscillation control"
+       }
+   ]
+
+.. note::
+
+   Not all fans support all points. Check the fan entity in Home Assistant Developer Tools > States to see available attributes (e.g., supported preset modes or direction).
+
 
 Transfer the registers files and the config files into the VOLTTRON config store using the commands below:
 
@@ -412,17 +487,9 @@ Integration tests require a live Home Assistant instance with actual devices/hel
     # Run all tests (unit + integration)
     pytest services/core/PlatformDriverAgent/tests/test_home_assistant.py -v
 
-**Test Summary:**
+**Test Summary (high level):**
 
-- **Unit Tests**: 70+ tests (no Home Assistant required)
+- **Unit Tests (mocked; no Home Assistant needed):** cover fan, switch, and cover write-access and validation.
+- **Integration Tests (require Home Assistant):** basic toggle helper + device-specific fan/switch/cover flows when entity IDs and credentials are provided.
 
-  - Fan: 35 tests
-  - Switch: 11 tests
-  - Cover: 24 tests
-
-- **Integration Tests**: 21+ tests (require Home Assistant)
-
-  - Basic: 3 tests
-  - Fan: 7 tests
-  - Switch: 4 tests
-  - Cover: 6 tests
+Refer to the individual test classes in ``services/core/PlatformDriverAgent/tests/test_home_assistant.py`` for the exact test coverage per device type.

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -22,6 +22,26 @@
 # ===----------------------------------------------------------------------===
 # }}}
 
+"""
+Home Assistant Interface for VOLTTRON Platform Driver
+
+This module provides a driver interface for integrating Home Assistant devices
+with the VOLTTRON platform. It supports reading and writing to various Home 
+Assistant entity types including lights, thermostats, fans, switches, covers, 
+and input_booleans.
+
+Architecture:
+-------------
+Uses Strategy Pattern with dictionary-based dispatch for handling different device types.
+Each device type has dedicated read/write handler methods for improved maintainability.
+
+Adding New Device Types:
+------------------------
+1. Create write handler: _handle_DEVICE_write(self, register, entity_point)
+2. Create scrape handler: _scrape_DEVICE(self, register, entity_point, entity_data, result)
+3. Register both in __init__ dictionaries
+4. Add API methods for Home Assistant calls
+"""
 
 import random
 from math import pi
@@ -35,6 +55,8 @@ import requests
 from requests import get
 
 _log = logging.getLogger(__name__)
+
+# Type mapping for registry configuration
 type_mapping = {"string": str,
                 "int": int,
                 "integer": int,
@@ -44,6 +66,14 @@ type_mapping = {"string": str,
 
 
 class HomeAssistantRegister(BaseRegister):
+    """
+    Register for Home Assistant entities.
+    
+    Extends BaseRegister to include Home Assistant-specific attributes:
+    - entity_id: The Home Assistant entity identifier (e.g., 'light.living_room')
+    - entity_point: The specific point being controlled (e.g., 'state', 'brightness')
+    - reg_type: The expected data type for this register
+    """
     def __init__(self, read_only, pointName, units, reg_type, attributes, entity_id, entity_point, default_value=None,
                  description=''):
         super(HomeAssistantRegister, self).__init__("byte", read_only, pointName, units, description='')
@@ -55,6 +85,20 @@ class HomeAssistantRegister(BaseRegister):
 
 
 def _post_method(url, headers, data, operation_description):
+    """
+    Centralized POST request handler for Home Assistant API calls.
+    
+    Provides consistent error handling and logging for all API operations.
+    
+    Args:
+        url: The API endpoint URL
+        headers: HTTP headers including authorization
+        data: JSON payload to send
+        operation_description: Human-readable description for logging
+        
+    Raises:
+        Exception: If the API call fails
+    """
     err = None
     try:
         _log.info("Calling Home Assistant service: url=%s, data=%s, operation=%s", url, data, operation_description)
@@ -73,20 +117,82 @@ def _post_method(url, headers, data, operation_description):
 
 
 class Interface(BasicRevert, BaseInterface):
+    """
+    Home Assistant interface for VOLTTRON Platform Driver.
+    
+    This class implements the bridge between VOLTTRON and Home Assistant,
+    handling both read (scrape) and write (set_point) operations for multiple
+    device types.
+    
+    Design Pattern: Strategy Pattern
+    --------------------------------
+    Different device types are handled by separate handler methods that are
+    registered in dictionaries. This makes the code:
+    - Easy to extend with new device types
+    - Easy to test (each handler can be tested independently)
+    - Easy to maintain (device-specific logic is isolated)
+    
+    Supported Devices:
+    -----------------
+    - Lights (state, brightness)
+    - Thermostats (state/mode, temperature)
+    - Fans (state, percentage, preset_mode, direction, oscillating)
+    - Switches (state)
+    - Covers (state, position, tilt_position)
+    - Input Booleans (state)
+    """
+    
     def __init__(self, **kwargs):
         super(Interface, self).__init__(**kwargs)
+        
+        # Configuration properties
         self.point_name = None
         self.ip_address = None
         self.access_token = None
         self.port = None
         self.units = None
+        
+        # ====================================================================
+        # HANDLER REGISTRATION (Strategy Pattern)
+        # ====================================================================
+        # These dictionaries map entity type prefixes to their handler methods.
+        # To add a new device type, simply add an entry here and implement
+        # the corresponding handler method below.
+        
+        # Write operation handlers: route set_point calls to device-specific logic
+        self._write_handlers = {
+            "light.": self._handle_light_write,
+            "input_boolean.": self._handle_input_boolean_write,
+            "fan.": self._handle_fan_write,
+            "climate.": self._handle_thermostat_write,  # climate = thermostat in Home Assistant
+            "switch.": self._handle_switch_write,
+            "cover.": self._handle_cover_write,
+        }
+        
+        # Read operation handlers: route scrape calls to device-specific logic
+        self._scrape_handlers = {
+            "climate.": self._scrape_thermostat,
+            "fan.": self._scrape_fan,
+            "switch.": self._scrape_switch,
+            "cover.": self._scrape_cover,
+            "light.": self._scrape_light_or_input_boolean,
+            "input_boolean.": self._scrape_light_or_input_boolean,
+        }
 
     def configure(self, config_dict, registry_config_str):
+        """
+        Configure the interface with connection details and register definitions.
+        
+        Args:
+            config_dict: Dictionary containing ip_address, access_token, and port
+            registry_config_str: Registry configuration defining the points to monitor
+        """
+        # Extract connection configuration
         self.ip_address = config_dict.get("ip_address", None)
         self.access_token = config_dict.get("access_token", None)
         self.port = config_dict.get("port", None)
 
-        # Check for None values
+        # Validate required configuration (Fail-fast principle)
         if self.ip_address is None:
             _log.error("IP address is not set.")
             raise ValueError("IP address is required.")
@@ -97,12 +203,23 @@ class Interface(BasicRevert, BaseInterface):
             _log.error("Port is not set.")
             raise ValueError("Port is required.")
 
+        # Parse and create registers from configuration
         self.parse_config(registry_config_str)
 
     def get_point(self, point_name):
+        """
+        Read a single point value from Home Assistant.
+        
+        Args:
+            point_name: The VOLTTRON point name to read
+            
+        Returns:
+            The current value of the point
+        """
         register = self.get_register_by_name(point_name)
-
         entity_data = self.get_entity_data(register.entity_id)
+        
+        # Handle state vs. attribute reads
         if register.point_name == "state":
             result = entity_data.get("state", None)
             return result
@@ -110,207 +227,362 @@ class Interface(BasicRevert, BaseInterface):
             value = entity_data.get("attributes", {}).get(f"{register.point_name}", 0)
             return value
 
+    # ========================================================================
+    # WRITE OPERATION ROUTING (Strategy Pattern Entry Point)
+    # ========================================================================
+    
     def _set_point(self, point_name, value):
+        """
+        Set a point value in Home Assistant.
+        
+        This is the main entry point for write operations. It:
+        1. Validates the point is writable
+        2. Converts the value to the correct type
+        3. Routes to the appropriate device handler based on entity_id prefix
+        
+        Design Note: This method follows the Open/Closed Principle - it's open
+        for extension (add new handlers) but closed for modification (no need
+        to change this method when adding new device types).
+        
+        Args:
+            point_name: The VOLTTRON point name to write
+            value: The value to write
+            
+        Returns:
+            The value that was written
+            
+        Raises:
+            IOError: If the point is read-only
+            ValueError: If the entity type is not supported
+        """
+        # Get the register and validate it's writable
         register = self.get_register_by_name(point_name)
         if register.read_only:
-            raise IOError(
-                "Trying to write to a point configured read only: " + point_name)
-        register.value = register.reg_type(value)  # setting the value
-        entity_point = register.entity_point
-        # Changing lights values in home assistant based off of register value.
-        if "light." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.turn_on_lights(register.entity_id)
-                    elif register.value == 0:
-                        self.turn_off_lights(register.entity_id)
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.info(error_msg)
-                    raise ValueError(error_msg)
-
-            elif entity_point == "brightness":
-                if isinstance(register.value, int) and 0 <= register.value <= 255:  # Make sure its int and within range
-                    self.change_brightness(register.entity_id, register.value)
-                else:
-                    error_msg = "Brightness value should be an integer between 0 and 255"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                error_msg = f"Unexpected point_name {point_name} for register {register.entity_id}"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
-
-        elif "input_boolean." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.set_input_boolean(register.entity_id, "on")
-                    elif register.value == 0:
-                        self.set_input_boolean(register.entity_id, "off")
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.info(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                _log.info(f"Currently, input_booleans only support state")
-
-        # Changing fan values.
-        elif "fan." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.turn_on_fan(register.entity_id)
-                    elif register.value == 0:
-                        self.turn_off_fan(register.entity_id)
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-
-            elif entity_point == "percentage":
-                if isinstance(register.value, int) and 0 <= register.value <= 100:
-                    self.set_fan_percentage(register.entity_id, register.value)
-                else:
-                    error_msg = "Fan percentage value should be an integer between 0 and 100"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-
-            elif entity_point == "preset_mode":
-                if isinstance(register.value, str) and register.value:
-                    self.set_fan_preset_mode(register.entity_id, register.value)
-                else:
-                    error_msg = "Fan preset_mode value should be a non-empty string"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-
-            elif entity_point == "direction":
-                if isinstance(register.value, str) and register.value in ["forward", "reverse"]:
-                    self.set_fan_direction(register.entity_id, register.value)
-                else:
-                    error_msg = "Fan direction value should be 'forward' or 'reverse'"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-
-            elif entity_point == "oscillating":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    self.set_fan_oscillation(register.entity_id, bool(register.value))
-                elif isinstance(register.value, bool):
-                    self.set_fan_oscillation(register.entity_id, register.value)
-                else:
-                    error_msg = "Fan oscillating value should be 0, 1, True, or False"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-
-            else:
-                error_msg = f"Unexpected entity_point {entity_point} for fan {register.entity_id}. " \
-                            f"Supported: state, percentage, preset_mode, direction, oscillating"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
-
-        # Changing thermostat values.
-        elif "climate." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 2, 3, 4]:
-                    if register.value == 0:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="off")
-                    elif register.value == 2:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="heat")
-                    elif register.value == 3:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="cool")
-                    elif register.value == 4:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="auto")
-                else:
-                    error_msg = f"Climate state should be an integer value of 0, 2, 3, or 4"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            elif entity_point == "temperature":
-                self.set_thermostat_temperature(entity_id=register.entity_id, temperature=register.value)
-
-            else:
-                error_msg = f"Currently set_point is supported only for thermostats state and temperature {register.entity_id}"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
+            raise IOError(f"Trying to write to a point configured read only: {point_name}")
         
-        # Changing switch values.
-        elif "switch." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.turn_on_switch(register.entity_id)
-                    elif register.value == 0:
-                        self.turn_off_switch(register.entity_id)
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                error_msg = f"Unexpected entity_point {entity_point} for switch {register.entity_id}. " \
-                            f"Supported: state"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
+        # Convert value to the expected type
+        register.value = register.reg_type(value)
+        entity_point = register.entity_point
+        
+        # Find the appropriate handler using Strategy Pattern (O(1) lookup)
+        handler = self._get_entity_handler(register.entity_id, self._write_handlers)
+        
+        if handler:
+            # Delegate to device-specific handler
+            return handler(register, entity_point)
+        
+        # No handler found - entity type not supported
+        error_msg = (
+            f"Unsupported entity_id: {register.entity_id}. "
+            f"Supported types: {', '.join(self._write_handlers.keys())}"
+        )
+        _log.error(error_msg)
+        raise ValueError(error_msg)
 
-        # Changing cover values.
-        elif "cover." in register.entity_id:
-            if entity_point == "state":
-                # State values: 0=closed, 1=open, 2=stop
-                if isinstance(register.value, int) and register.value in [0, 1, 2]:
-                    if register.value == 0:
-                        self.close_cover(register.entity_id)
-                    elif register.value == 1:
-                        self.open_cover(register.entity_id)
-                    elif register.value == 2:
-                        self.stop_cover(register.entity_id)
-                else:
-                    error_msg = f"Cover state should be an integer value of 0 (close), 1 (open), or 2 (stop)"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            elif entity_point == "position" or entity_point == "current_position":
-                # Position: 0-100 (0=closed, 100=fully open)
-                if isinstance(register.value, (int, float)) and 0 <= register.value <= 100:
-                    self.set_cover_position(register.entity_id, register.value)
-                else:
-                    error_msg = f"Cover position should be a number between 0 and 100, got {register.value}"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            elif entity_point == "tilt_position" or entity_point == "current_tilt_position":
-                # Tilt position: 0-100
-                if isinstance(register.value, (int, float)) and 0 <= register.value <= 100:
-                    self.set_cover_tilt_position(register.entity_id, register.value)
-                else:
-                    error_msg = f"Cover tilt_position should be a number between 0 and 100, got {register.value}"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                error_msg = f"Unsupported entity_point '{entity_point}' for cover {register.entity_id}. " \
-                            f"Supported points: state, position, current_position, tilt_position, current_tilt_position"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
-        else:
-            error_msg = f"Unsupported entity_id: {register.entity_id}. " \
-                        f"Currently set_point is supported only for thermostats, lights, input_booleans, and fans"
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+    def _get_entity_handler(self, entity_id, handler_dict):
+        """
+        Get the appropriate handler for an entity based on its type prefix.
+        
+        This is a key routing method that enables the Strategy Pattern.
+        It matches entity IDs like 'light.living_room' to handlers registered
+        for the 'light.' prefix.
+        
+        Args:
+            entity_id: The Home Assistant entity ID (e.g., 'light.living_room')
+            handler_dict: Dictionary mapping prefixes to handler methods
+            
+        Returns:
+            The handler method, or None if no match found
+        """
+        for prefix, handler in handler_dict.items():
+            if entity_id.startswith(prefix):
+                return handler
+        return None
+
+    # ========================================================================
+    # VALIDATION HELPERS (DRY Principle)
+    # ========================================================================
+    # These methods extract common validation patterns to avoid code duplication.
+    # Each provides consistent error messages and type checking.
+    
+    def _validate_binary_state(self, register, allowed_values=(0, 1)):
+        """
+        Validate that a value is one of the allowed integer states.
+        
+        Common pattern for on/off controls where 0=off, 1=on.
+        
+        Args:
+            register: The register containing the value to validate
+            allowed_values: Tuple of allowed integer values
+            
+        Returns:
+            The validated value
+            
+        Raises:
+            ValueError: If validation fails
+        """
+        if not isinstance(register.value, int) or register.value not in allowed_values:
+            raise ValueError(
+                f"State value for {register.entity_id} should be an integer "
+                f"from {allowed_values}, got {register.value}"
+            )
         return register.value
 
-    def get_entity_data(self, point_name):
+    def _validate_range(self, register, min_val, max_val, value_name="value"):
+        """
+        Validate that a numeric value is within a specified range.
+        
+        Used for percentage values, brightness levels, etc.
+        
+        Args:
+            register: The register containing the value to validate
+            min_val: Minimum allowed value (inclusive)
+            max_val: Maximum allowed value (inclusive)
+            value_name: Human-readable name for error messages
+            
+        Returns:
+            The validated value
+            
+        Raises:
+            ValueError: If validation fails
+        """
+        if not isinstance(register.value, (int, float)) or not (min_val <= register.value <= max_val):
+            raise ValueError(
+                f"{value_name} for {register.entity_id} should be between "
+                f"{min_val} and {max_val}, got {register.value}"
+            )
+        return register.value
+
+    def _validate_string_choice(self, register, choices, value_name="value"):
+        """
+        Validate that a string value is one of the allowed choices.
+        
+        Used for enumerated string values like fan direction ('forward'/'reverse').
+        
+        Args:
+            register: The register containing the value to validate
+            choices: List of allowed string values
+            value_name: Human-readable name for error messages
+            
+        Returns:
+            The validated value
+            
+        Raises:
+            ValueError: If validation fails
+        """
+        if not isinstance(register.value, str) or register.value not in choices:
+            # Format choices as 'choice1' or 'choice2' for better readability
+            choices_str = "' or '".join(choices)
+            raise ValueError(
+                f"{value_name} for {register.entity_id} should be '{choices_str}', "
+                f"got '{register.value}'"
+            )
+        return register.value
+
+    # ========================================================================
+    # WRITE HANDLERS (Device-Specific Logic)
+    # ========================================================================
+    
+    def _handle_light_write(self, register, entity_point):
+        """
+        Handle write operations for light entities.
+        
+        Supported entity_points:
+        - state: Turn light on (1) or off (0)
+        - brightness: Set brightness level (0-255)
+        """
+        if entity_point == "state":
+            self._validate_binary_state(register)
+            action = self.turn_on_lights if register.value == 1 else self.turn_off_lights
+            action(register.entity_id)
+            
+        elif entity_point == "brightness":
+            self._validate_range(register, 0, 255, "Brightness")
+            self.change_brightness(register.entity_id, register.value)
+            
+        else:
+            raise ValueError(
+                f"Unexpected entity_point '{entity_point}' for light {register.entity_id}. "
+                f"Supported: state, brightness"
+            )
+        return register.value
+
+    def _handle_input_boolean_write(self, register, entity_point):
+        """Handle write operations for input_boolean entities (state only)."""
+        if entity_point == "state":
+            self._validate_binary_state(register)
+            state = "on" if register.value == 1 else "off"
+            self.set_input_boolean(register.entity_id, state)
+        else:
+            _log.info(f"Currently, input_booleans only support 'state' entity_point")
+        return register.value
+
+    def _handle_fan_write(self, register, entity_point):
+        """
+        Handle write operations for fan entities.
+        
+        Uses nested dispatch pattern for multiple controllable attributes.
+        
+        Supported entity_points:
+        - state: Turn fan on (1) or off (0)
+        - percentage: Set fan speed (0-100)
+        - preset_mode: Set preset mode (string, e.g., 'auto', 'sleep')
+        - direction: Set rotation direction ('forward' or 'reverse')
+        - oscillating: Enable/disable oscillation (0/1 or True/False)
+        """
+        # Nested handler dictionary for fan-specific operations
+        handlers = {
+            "state": lambda: self._handle_fan_state(register),
+            "percentage": lambda: self._handle_fan_percentage(register),
+            "preset_mode": lambda: self._handle_fan_preset_mode(register),
+            "direction": lambda: self._handle_fan_direction(register),
+            "oscillating": lambda: self._handle_fan_oscillating(register),
+        }
+        
+        handler = handlers.get(entity_point)
+        if handler:
+            return handler()
+        
+        raise ValueError(
+            f"Unexpected entity_point '{entity_point}' for fan {register.entity_id}. "
+            f"Supported: {', '.join(handlers.keys())}"
+        )
+
+    def _handle_fan_state(self, register):
+        """Handle fan on/off state changes."""
+        self._validate_binary_state(register)
+        action = self.turn_on_fan if register.value == 1 else self.turn_off_fan
+        action(register.entity_id)
+        return register.value
+
+    def _handle_fan_percentage(self, register):
+        """Handle fan speed percentage changes (0-100)."""
+        self._validate_range(register, 0, 100, "Fan percentage")
+        self.set_fan_percentage(register.entity_id, register.value)
+        return register.value
+
+    def _handle_fan_preset_mode(self, register):
+        """Handle fan preset mode changes (e.g., 'auto', 'sleep')."""
+        if not isinstance(register.value, str) or not register.value:
+            raise ValueError(f"Fan preset_mode for {register.entity_id} should be a non-empty string")
+        self.set_fan_preset_mode(register.entity_id, register.value)
+        return register.value
+
+    def _handle_fan_direction(self, register):
+        """Handle fan rotation direction changes ('forward' or 'reverse')."""
+        self._validate_string_choice(register, ["forward", "reverse"], "Fan direction")
+        self.set_fan_direction(register.entity_id, register.value)
+        return register.value
+
+    def _handle_fan_oscillating(self, register):
+        """Handle fan oscillation changes (accepts both bool and int 0/1)."""
+        if isinstance(register.value, bool):
+            oscillating = register.value
+        elif isinstance(register.value, int) and register.value in [0, 1]:
+            oscillating = bool(register.value)
+        else:
+            raise ValueError(
+                f"Fan oscillating value for {register.entity_id} should be "
+                f"0, 1, True, or False, got {register.value}"
+            )
+        self.set_fan_oscillation(register.entity_id, oscillating)
+        return register.value
+
+    def _handle_thermostat_write(self, register, entity_point):
+        """
+        Handle write operations for thermostat (climate) entities.
+        
+        Supported entity_points:
+        - state: Set HVAC mode (0=off, 2=heat, 3=cool, 4=auto)
+        - temperature: Set target temperature
+        """
+        if entity_point == "state":
+            self._validate_binary_state(register, allowed_values=(0, 2, 3, 4))
+            mode_mapping = {0: "off", 2: "heat", 3: "cool", 4: "auto"}
+            self.change_thermostat_mode(
+                entity_id=register.entity_id, 
+                mode=mode_mapping[register.value]
+            )
+        elif entity_point == "temperature":
+            self.set_thermostat_temperature(
+                entity_id=register.entity_id, 
+                temperature=register.value
+            )
+        else:
+            raise ValueError(
+                f"Unexpected entity_point '{entity_point}' for thermostat {register.entity_id}. "
+                f"Supported: state, temperature"
+            )
+        return register.value
+
+    def _handle_switch_write(self, register, entity_point):
+        """Handle write operations for switch entities (state only)."""
+        if entity_point == "state":
+            self._validate_binary_state(register)
+            action = self.turn_on_switch if register.value == 1 else self.turn_off_switch
+            action(register.entity_id)
+        else:
+            raise ValueError(
+                f"Unexpected entity_point '{entity_point}' for switch {register.entity_id}. "
+                f"Supported: state"
+            )
+        return register.value
+
+    def _handle_cover_write(self, register, entity_point):
+        """
+        Handle write operations for cover entities (blinds, shades, garage doors).
+        
+        Supported entity_points:
+        - state: Control cover (0=close, 1=open, 2=stop)
+        - position/current_position: Set position (0-100)
+        - tilt_position/current_tilt_position: Set tilt angle (0-100)
+        """
+        if entity_point == "state":
+            self._validate_binary_state(register, allowed_values=(0, 1, 2))
+            actions = {0: self.close_cover, 1: self.open_cover, 2: self.stop_cover}
+            actions[register.value](register.entity_id)
+            
+        elif entity_point in ["position", "current_position"]:
+            self._validate_range(register, 0, 100, "Cover position")
+            self.set_cover_position(register.entity_id, register.value)
+            
+        elif entity_point in ["tilt_position", "current_tilt_position"]:
+            self._validate_range(register, 0, 100, "Cover tilt position")
+            self.set_cover_tilt_position(register.entity_id, register.value)
+            
+        else:
+            raise ValueError(
+                f"Unsupported entity_point '{entity_point}' for cover {register.entity_id}. "
+                f"Supported: state, position, current_position, tilt_position, current_tilt_position"
+            )
+        return register.value
+
+    # ========================================================================
+    # READ OPERATIONS (Scraping)
+    # ========================================================================
+    
+    def get_entity_data(self, entity_id):
+        """Fetch current state and attributes for an entity from Home Assistant."""
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        # the /states grabs current state AND attributes of a specific entity
-        url = f"http://{self.ip_address}:{self.port}/api/states/{point_name}"
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            return response.json()  # return the json attributes from entity
-        else:
-            error_msg = f"Request failed with status code {response.status_code}, Point name: {point_name}, " \
-                        f"response: {response.text}"
+        url = f"http://{self.ip_address}:{self.port}/api/states/{entity_id}"
+        
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            error_msg = (
+                f"Failed to get entity data for {entity_id}. "
+                f"Status: {getattr(response, 'status_code', 'N/A')}, Error: {e}"
+            )
             _log.error(error_msg)
             raise Exception(error_msg)
 
     def _scrape_all(self):
+        """Read all register values from Home Assistant (scrape operation)."""
         result = {}
         read_registers = self.get_registers_by_type("byte", True)
         write_registers = self.get_registers_by_type("byte", False)
@@ -319,134 +591,131 @@ class Interface(BasicRevert, BaseInterface):
             entity_id = register.entity_id
             entity_point = register.entity_point
             try:
-                entity_data = self.get_entity_data(entity_id)  # Using Entity ID to get data
-                if "climate." in entity_id:  # handling thermostats.
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Giving thermostat states an equivalent number.
-                        if state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                        elif state == "heat":
-                            register.value = 2
-                            result[register.point_name] = 2
-                        elif state == "cool":
-                            register.value = 3
-                            result[register.point_name] = 3
-                        elif state == "auto":
-                            register.value = 4
-                            result[register.point_name] = 4
-                        else:
-                            error_msg = f"State {state} from {entity_id} is not yet supported"
-                            _log.error(error_msg)
-                            ValueError(error_msg)
-                    # Assigning attributes
-                    else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                # handling fan states
-                elif "fan." in entity_id:
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Converting fan states to numbers (on=1, off=0).
-                        if state == "on":
-                            register.value = 1
-                            result[register.point_name] = 1
-                        elif state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                        else:
-                            register.value = state
-                            result[register.point_name] = state
-                    elif entity_point == "oscillating":
-                        # Convert boolean to int for consistency
-                        oscillating = entity_data.get("attributes", {}).get("oscillating", False)
-                        register.value = 1 if oscillating else 0
-                        result[register.point_name] = register.value
-                    else:
-                        # Handle percentage, preset_mode, direction, and other attributes
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", None)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                # handling switch states
-                elif "switch." in entity_id:
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Converting switch states to numbers (on=1, off=0).
-                        if state == "on":
-                            register.value = 1
-                            result[register.point_name] = 1
-                        elif state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                        else:
-                            register.value = state
-                            result[register.point_name] = state
-                    else:
-                        # Handle other switch attributes
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", None)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                # handling cover states
-                elif "cover." in entity_id:
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Converting cover states to numbers: closed=0, open=1, opening=1, closing=0
-                        if state in ["open", "opening"]:
-                            register.value = 1
-                            result[register.point_name] = 1
-                        elif state in ["closed", "closing"]:
-                            register.value = 0
-                            result[register.point_name] = 0
-                        else:
-                            # Handle unknown state
-                            _log.warning(f"Unknown cover state '{state}' for {entity_id}, defaulting to 0")
-                            register.value = 0
-                            result[register.point_name] = 0
-                    else:
-                        # Handling position, tilt_position, and other attributes
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                # handling light states
-                elif "light." in entity_id or "input_boolean." in entity_id:  # Checks for lights or input bools since they have the same states.
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Converting light states to numbers.
-                        if state == "on":
-                            register.value = 1
-                            result[register.point_name] = 1
-                        elif state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                    else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                else:  # handling all devices that are not thermostats, fans, or light states
-                    if entity_point == "state":
-
-                        state = entity_data.get("state", None)
-                        register.value = state
-                        result[register.point_name] = state
-                    # Assigning attributes
-                    else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
+                entity_data = self.get_entity_data(entity_id)
+                self._scrape_entity(register, entity_point, entity_data, result)
             except Exception as e:
-                _log.error(f"An unexpected error occurred for entity_id: {entity_id}: {e}")
+                _log.error(f"Error scraping entity {entity_id}: {e}")
 
         return result
 
-    def parse_config(self, config_dict):
+    def _scrape_entity(self, register, entity_point, entity_data, result):
+        """Route entity scrape to appropriate handler based on entity type."""
+        handler = self._get_entity_handler(register.entity_id, self._scrape_handlers)
+        
+        if handler:
+            handler(register, entity_point, entity_data, result)
+        else:
+            # Fallback for unknown entity types
+            self._scrape_generic(register, entity_point, entity_data, result)
 
+    def _scrape_generic(self, register, entity_point, entity_data, result):
+        """Generic scraper for unknown entity types - reads state or attributes directly."""
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            register.value = state
+            result[register.point_name] = state
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, 0)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    # ========================================================================
+    # READ HANDLERS (Device-Specific Scraping)
+    # ========================================================================
+    
+    def _scrape_thermostat(self, register, entity_point, entity_data, result):
+        """
+        Scrape thermostat state and attributes.
+        Transforms HVAC modes to numeric codes: off=0, heat=2, cool=3, auto=4
+        """
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            state_mapping = {"off": 0, "heat": 2, "cool": 3, "auto": 4}
+            
+            if state in state_mapping:
+                register.value = state_mapping[state]
+                result[register.point_name] = state_mapping[state]
+            else:
+                _log.warning(f"Unsupported thermostat state '{state}' for {register.entity_id}")
+                register.value = None
+                result[register.point_name] = None
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, 0)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    def _scrape_fan(self, register, entity_point, entity_data, result):
+        """Scrape fan state and attributes (converts on/off to 1/0)."""
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            state_value = 1 if state == "on" else 0 if state == "off" else state
+            register.value = state_value
+            result[register.point_name] = state_value
+            
+        elif entity_point == "oscillating":
+            oscillating = entity_data.get("attributes", {}).get("oscillating", False)
+            register.value = 1 if oscillating else 0
+            result[register.point_name] = register.value
+            
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, None)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    def _scrape_switch(self, register, entity_point, entity_data, result):
+        """Scrape switch state and attributes (converts on/off to 1/0)."""
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            state_value = 1 if state == "on" else 0 if state == "off" else state
+            register.value = state_value
+            result[register.point_name] = state_value
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, None)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    def _scrape_cover(self, register, entity_point, entity_data, result):
+        """Scrape cover state and attributes (open/opening=1, closed/closing=0)."""
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            if state in ["open", "opening"]:
+                state_value = 1
+            elif state in ["closed", "closing"]:
+                state_value = 0
+            else:
+                _log.warning(f"Unknown cover state '{state}' for {register.entity_id}, defaulting to 0")
+                state_value = 0
+            
+            register.value = state_value
+            result[register.point_name] = state_value
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, 0)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    def _scrape_light_or_input_boolean(self, register, entity_point, entity_data, result):
+        """Scrape light/input_boolean state and attributes (converts on/off to 1/0)."""
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            state_value = 1 if state == "on" else 0 if state == "off" else None
+            register.value = state_value
+            result[register.point_name] = state_value
+        else:
+            attribute = entity_data.get("attributes", {}).get(entity_point, 0)
+            register.value = attribute
+            result[register.point_name] = attribute
+
+    # ========================================================================
+    # CONFIGURATION PARSING
+    # ========================================================================
+    
+    def parse_config(self, config_dict):
+        """Parse registry configuration and create registers."""
         if config_dict is None:
             return
+            
         for regDef in config_dict:
-
-            if not regDef['Entity ID']:
+            if not regDef.get('Entity ID'):
                 continue
 
             read_only = str(regDef.get('Writable', '')).lower() != 'true'
@@ -455,13 +724,12 @@ class Interface(BasicRevert, BaseInterface):
             self.point_name = regDef['Volttron Point Name']
             self.units = regDef['Units']
             description = regDef.get('Notes', '')
-            default_value = ("Starting Value")
+            default_value = "Starting Value"
             type_name = regDef.get("Type", 'string')
             reg_type = type_mapping.get(type_name, str)
             attributes = regDef.get('Attributes', {})
-            register_type = HomeAssistantRegister
 
-            register = register_type(
+            register = HomeAssistantRegister(
                 read_only,
                 self.point_name,
                 self.units,
@@ -470,60 +738,75 @@ class Interface(BasicRevert, BaseInterface):
                 entity_id,
                 entity_point,
                 default_value=default_value,
-                description=description)
+                description=description
+            )
 
             if default_value is not None:
                 self.set_default(self.point_name, register.value)
 
             self.insert_register(register)
 
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - LIGHTS
+    # ========================================================================
+    
     def turn_off_lights(self, entity_id):
+        """Turn off a light entity."""
         url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_off"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+        payload = {"entity_id": entity_id}
+        _post_method(url, headers, payload, f"turn off {entity_id}")
+
+    def turn_on_lights(self, entity_id):
+        """Turn on a light entity."""
+        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+        payload = {"entity_id": entity_id}
+        _post_method(url, headers, payload, f"turn on {entity_id}")
+
+    def change_brightness(self, entity_id, value):
+        """Change the brightness of a light entity (0-255)."""
+        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
         payload = {
             "entity_id": entity_id,
+            "brightness": value,
         }
-        _post_method(url, headers, payload, f"turn off {entity_id}")
+        _post_method(url, headers, payload, f"set brightness of {entity_id} to {value}")
 
-    def turn_on_lights(self, entity_id):
-        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
-        headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "Content-Type": "application/json",
-        }
-
-        payload = {
-            "entity_id": f"{entity_id}"
-        }
-        _post_method(url, headers, payload, f"turn on {entity_id}")
-
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - THERMOSTATS
+    # ========================================================================
+    
     def change_thermostat_mode(self, entity_id, mode):
-        # Check if enttiy_id startswith climate.
+        """Change the HVAC mode of a thermostat (off, heat, cool, auto)."""
         if not entity_id.startswith("climate."):
-            _log.error(f"{entity_id} is not a valid thermostat entity ID.")
-            return
-        # Build header
+            raise ValueError(f"{entity_id} is not a valid thermostat entity ID.")
+
         url = f"http://{self.ip_address}:{self.port}/api/services/climate/set_hvac_mode"
         headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "content-type": "application/json",
+            "Authorization": f"Bearer {self.access_token}",
+            "content-type": "application/json",
         }
-        # Build data
         data = {
             "entity_id": entity_id,
             "hvac_mode": mode,
         }
-        # Post data
         _post_method(url, headers, data, f"change mode of {entity_id} to {mode}")
 
     def set_thermostat_temperature(self, entity_id, temperature):
-        # Check if the provided entity_id starts with "climate."
+        """Set the target temperature of a thermostat."""
         if not entity_id.startswith("climate."):
-            _log.error(f"{entity_id} is not a valid thermostat entity ID.")
-            return
+            raise ValueError(f"{entity_id} is not a valid thermostat entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/climate/set_temperature"
         headers = {
@@ -531,9 +814,10 @@ class Interface(BasicRevert, BaseInterface):
             "content-type": "application/json",
         }
 
+        # Convert temperature if units are Celsius
         if self.units == "C":
             converted_temp = round((temperature - 32) * 5/9, 1)
-            _log.info(f"Converted temperature {converted_temp}")
+            _log.info(f"Converted temperature from {temperature}°F to {converted_temp}°C")
             data = {
                 "entity_id": entity_id,
                 "temperature": converted_temp,
@@ -545,44 +829,30 @@ class Interface(BasicRevert, BaseInterface):
             }
         _post_method(url, headers, data, f"set temperature of {entity_id} to {temperature}")
 
-    def change_brightness(self, entity_id, value):
-        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
-        headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "Content-Type": "application/json",
-        }
-        # ranges from 0 - 255
-        payload = {
-            "entity_id": f"{entity_id}",
-            "brightness": value,
-        }
-
-        _post_method(url, headers, payload, f"set brightness of {entity_id} to {value}")
-
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - INPUT BOOLEANS
+    # ========================================================================
+    
     def set_input_boolean(self, entity_id, state):
+        """Set the state of an input_boolean entity (on/off)."""
         service = 'turn_on' if state == 'on' else 'turn_off'
         url = f"http://{self.ip_address}:{self.port}/api/services/input_boolean/{service}"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-
-        payload = {
-            "entity_id": entity_id
-        }
-
+        payload = {"entity_id": entity_id}
+        
         response = requests.post(url, headers=headers, json=payload)
-
-        # Optionally check for a successful response
         if response.status_code == 200:
             print(f"Successfully set {entity_id} to {state}")
         else:
             print(f"Failed to set {entity_id} to {state}: {response.text}")
 
-    # Fan control methods
-    # Reference: https://www.home-assistant.io/integrations/fan/
-    # API: https://developers.home-assistant.io/docs/api/rest/
-
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - FANS
+    # ========================================================================
+    
     def turn_on_fan(self, entity_id, percentage=None, preset_mode=None):
         """Turn on a fan device with optional percentage or preset_mode."""
         url = f"http://{self.ip_address}:{self.port}/api/services/fan/turn_on"
@@ -590,14 +860,11 @@ class Interface(BasicRevert, BaseInterface):
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         if percentage is not None:
             payload["percentage"] = percentage
         if preset_mode is not None:
             payload["preset_mode"] = preset_mode
-
         _post_method(url, headers, payload, f"turn on fan {entity_id}")
 
     def turn_off_fan(self, entity_id):
@@ -607,223 +874,162 @@ class Interface(BasicRevert, BaseInterface):
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"turn off fan {entity_id}")
 
     def set_fan_percentage(self, entity_id, percentage):
         """Set the speed percentage for a fan device (0-100)."""
         if not entity_id.startswith("fan."):
-            error_msg = f"{entity_id} is not a valid fan entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid fan entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/fan/set_percentage"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "percentage": percentage
-        }
+        payload = {"entity_id": entity_id, "percentage": percentage}
         _post_method(url, headers, payload, f"set fan {entity_id} percentage to {percentage}")
 
     def set_fan_preset_mode(self, entity_id, preset_mode):
-        """Set a preset mode for a fan device (e.g., 'Low', 'Medium', 'High', 'auto')."""
+        """Set a preset mode for a fan device."""
         if not entity_id.startswith("fan."):
-            error_msg = f"{entity_id} is not a valid fan entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid fan entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/fan/set_preset_mode"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "preset_mode": preset_mode
-        }
+        payload = {"entity_id": entity_id, "preset_mode": preset_mode}
         _post_method(url, headers, payload, f"set fan {entity_id} preset mode to {preset_mode}")
 
     def set_fan_direction(self, entity_id, direction):
         """Set the rotation direction for a fan device ('forward' or 'reverse')."""
         if not entity_id.startswith("fan."):
-            error_msg = f"{entity_id} is not a valid fan entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
-
+            raise ValueError(f"{entity_id} is not a valid fan entity ID.")
         if direction not in ["forward", "reverse"]:
-            error_msg = f"Invalid direction '{direction}'. Must be 'forward' or 'reverse'."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"Invalid direction '{direction}'. Must be 'forward' or 'reverse'.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/fan/set_direction"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "direction": direction
-        }
+        payload = {"entity_id": entity_id, "direction": direction}
         _post_method(url, headers, payload, f"set fan {entity_id} direction to {direction}")
 
     def set_fan_oscillation(self, entity_id, oscillating):
         """Set the oscillation for a fan device (True or False)."""
         if not entity_id.startswith("fan."):
-            error_msg = f"{entity_id} is not a valid fan entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid fan entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/fan/oscillate"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "oscillating": oscillating
-        }
+        payload = {"entity_id": entity_id, "oscillating": oscillating}
         _post_method(url, headers, payload, f"set fan {entity_id} oscillating to {oscillating}")
 
-    # Switch control methods
-    # Reference: https://www.home-assistant.io/integrations/switch/
-    # API: https://developers.home-assistant.io/docs/api/rest/
-
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - SWITCHES
+    # ========================================================================
+    
     def turn_on_switch(self, entity_id):
         """Turn on a switch device."""
         if not entity_id.startswith("switch."):
-            error_msg = f"{entity_id} is not a valid switch entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid switch entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/switch/turn_on"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"turn on switch {entity_id}")
 
     def turn_off_switch(self, entity_id):
         """Turn off a switch device."""
         if not entity_id.startswith("switch."):
-            error_msg = f"{entity_id} is not a valid switch entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid switch entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/switch/turn_off"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"turn off switch {entity_id}")
 
-    # Cover control methods
-    # Reference: https://www.home-assistant.io/integrations/cover/
-    # API: https://developers.home-assistant.io/docs/core/entity/cover/
-
+    # ========================================================================
+    # HOME ASSISTANT API METHODS - COVERS
+    # ========================================================================
+    
     def open_cover(self, entity_id):
-        """Open a cover device."""
+        """Open a cover device (blinds, garage door, etc.)."""
         if not entity_id.startswith("cover."):
-            error_msg = f"{entity_id} is not a valid cover entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid cover entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/cover/open_cover"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"open cover {entity_id}")
 
     def close_cover(self, entity_id):
         """Close a cover device."""
         if not entity_id.startswith("cover."):
-            error_msg = f"{entity_id} is not a valid cover entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid cover entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/cover/close_cover"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"close cover {entity_id}")
 
     def stop_cover(self, entity_id):
-        """Stop a cover device."""
+        """Stop a moving cover device."""
         if not entity_id.startswith("cover."):
-            error_msg = f"{entity_id} is not a valid cover entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"{entity_id} is not a valid cover entity ID.")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/cover/stop_cover"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id
-        }
+        payload = {"entity_id": entity_id}
         _post_method(url, headers, payload, f"stop cover {entity_id}")
 
     def set_cover_position(self, entity_id, position):
-        """Set the position of a cover device (0-100, where 0=closed and 100=fully open)."""
+        """Set the position of a cover device (0=fully closed, 100=fully open)."""
         if not entity_id.startswith("cover."):
-            error_msg = f"{entity_id} is not a valid cover entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
-
+            raise ValueError(f"{entity_id} is not a valid cover entity ID.")
         if not isinstance(position, (int, float)) or not 0 <= position <= 100:
-            error_msg = f"Position must be a number between 0 and 100, got {position}"
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"Position must be between 0 and 100, got {position}")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/cover/set_cover_position"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "position": int(position)
-        }
+        payload = {"entity_id": entity_id, "position": int(position)}
         _post_method(url, headers, payload, f"set position of {entity_id} to {position}")
 
     def set_cover_tilt_position(self, entity_id, tilt_position):
         """Set the tilt position of a cover device (0-100)."""
         if not entity_id.startswith("cover."):
-            error_msg = f"{entity_id} is not a valid cover entity ID."
-            _log.error(error_msg)
-            raise ValueError(error_msg)
-
+            raise ValueError(f"{entity_id} is not a valid cover entity ID.")
         if not isinstance(tilt_position, (int, float)) or not 0 <= tilt_position <= 100:
-            error_msg = f"Tilt position must be a number between 0 and 100, got {tilt_position}"
-            _log.error(error_msg)
-            raise ValueError(error_msg)
+            raise ValueError(f"Tilt position must be between 0 and 100, got {tilt_position}")
 
         url = f"http://{self.ip_address}:{self.port}/api/services/cover/set_cover_tilt_position"
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-        payload = {
-            "entity_id": entity_id,
-            "tilt_position": int(tilt_position)
-        }
+        payload = {"entity_id": entity_id, "tilt_position": int(tilt_position)}
         _post_method(url, headers, payload, f"set tilt position of {entity_id} to {tilt_position}")


### PR DESCRIPTION
# Description

1. Code Refactor 

Summary

Refactored the Home Assistant interface using industry-standard design patterns to improve maintainability, reduce complexity, and add support for 3 new device types (fans, switches, covers).

Key Improvements

- Strategy Pattern: Replaced 80+ line nested if-elif chain with dictionary-based handler dispatch (O(1) lookup)
- DRY Principle: Created 3 reusable validation helpers that eliminated 65% code duplication
- Single Responsibility: Separated device logic into focused handler methods (15-25 lines each)
- Open/Closed: New devices can be added in 4 simple steps without modifying core routing logic

2. Documentatiion

- Add the write-access for Fan documentation
- Build Documentation and capture screenshots

<img width="995" height="488" alt="Screenshot 2025-12-07 at 3 55 22 PM" src="https://github.com/user-attachments/assets/b78b6f42-69a9-43fb-846d-46013fd9e858" />
<img width="990" height="891" alt="Screenshot 2025-12-07 at 3 55 35 PM" src="https://github.com/user-attachments/assets/2190f145-9e97-4dfe-ba86-ec87c953de45" />
<img width="991" height="1090" alt="Screenshot 2025-12-07 at 3 55 46 PM" src="https://github.com/user-attachments/assets/47c7bf7d-f9f7-4142-bf7d-b3af063e1bed" />
<img width="992" height="1238" alt="Screenshot 2025-12-07 at 3 55 56 PM" src="https://github.com/user-attachments/assets/679cb905-f3fe-44d2-b3c9-19f9ea87da3a" />
<img width="990" height="1249" alt="Screenshot 2025-12-07 at 3 56 16 PM" src="https://github.com/user-attachments/assets/1970e88f-7922-442e-bcbd-81aeed6c6c73" />


Fixes # (issue)

#5 
#22 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
:~/volttron$ pytest services/core/PlatformDriverAgent/tests/test_home_assistant.py \
  -k "FanMocked or SwitchMocked or CoverMocked" -v
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.12.3, pytest-7.1.2, pluggy-1.6.0 -- /home/xuwang/volttron/env/bin/python
cachedir: .pytest_cache
rootdir: /home/xuwang/volttron, configfile: pytest.ini
plugins: asyncio-0.19.0, timeout-2.1.0, rerunfailures-10.2
asyncio: mode=Mode.AUTO
timeout: 300.0s
timeout method: signal
timeout func_only: False
collected 116 items / 57 deselected / 59 selected

services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_turn_on_fan PASSED                                                                                                  [  1%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_turn_on_fan_with_percentage PASSED                                                                                  [  3%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_turn_on_fan_with_preset_mode PASSED                                                                                 [  5%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_turn_off_fan PASSED                                                                                                 [  6%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_percentage PASSED                                                                                           [  8%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_percentage_invalid_entity PASSED                                                                            [ 10%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_preset_mode PASSED                                                                                          [ 11%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_preset_mode_invalid_entity PASSED                                                                           [ 13%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_direction_forward PASSED                                                                                    [ 15%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_direction_reverse PASSED                                                                                    [ 16%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_direction_invalid PASSED                                                                                    [ 18%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_direction_invalid_entity PASSED                                                                             [ 20%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_oscillation_on PASSED                                                                                       [ 22%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_oscillation_off PASSED                                                                                      [ 23%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_fan_oscillation_invalid_entity PASSED                                                                           [ 25%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_state_on PASSED                                                                                       [ 27%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_state_off PASSED                                                                                      [ 28%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_state_invalid PASSED                                                                                  [ 30%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_percentage PASSED                                                                                     [ 32%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_percentage_invalid PASSED                                                                             [ 33%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_preset_mode PASSED                                                                                    [ 35%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_direction PASSED                                                                                      [ 37%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_direction_invalid PASSED                                                                              [ 38%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_oscillating PASSED                                                                                    [ 40%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_set_point_fan_oscillating_off PASSED                                                                                [ 42%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_scrape_all_fan_state_on PASSED                                                                                      [ 44%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_scrape_all_fan_state_off PASSED                                                                                     [ 45%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_api_error_handling PASSED                                                                                           [ 47%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestFanMocked::test_request_exception_handling PASSED                                                                                   [ 49%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_turn_on_switch PASSED                                                                                            [ 50%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_turn_off_switch PASSED                                                                                           [ 52%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_turn_on_switch_invalid_entity PASSED                                                                             [ 54%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_turn_off_switch_invalid_entity PASSED                                                                            [ 55%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_set_point_switch_state_on PASSED                                                                                 [ 57%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_set_point_switch_state_off PASSED                                                                                [ 59%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_set_point_switch_state_invalid PASSED                                                                            [ 61%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_scrape_all_switch_state_on PASSED                                                                                [ 62%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestSwitchMocked::test_scrape_all_switch_state_off PASSED                                                                               [ 64%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_open_cover PASSED                                                                                                 [ 66%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_close_cover PASSED                                                                                                [ 67%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_stop_cover PASSED                                                                                                 [ 69%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_position PASSED                                                                                         [ 71%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_position_invalid_range PASSED                                                                           [ 72%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_position_negative PASSED                                                                                [ 74%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_position_invalid_entity PASSED                                                                          [ 76%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_tilt_position PASSED                                                                                    [ 77%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_cover_tilt_invalid_range PASSED                                                                               [ 79%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_open_cover_invalid_entity PASSED                                                                                  [ 81%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_close PASSED                                                                                      [ 83%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_open PASSED                                                                                       [ 84%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_stop PASSED                                                                                       [ 86%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_state_invalid PASSED                                                                              [ 88%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_position PASSED                                                                                   [ 89%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_position_invalid PASSED                                                                           [ 91%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_set_point_cover_tilt PASSED                                                                                       [ 93%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_scrape_all_cover_open PASSED                                                                                      [ 94%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_scrape_all_cover_closed PASSED                                                                                    [ 96%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_scrape_all_cover_opening PASSED                                                                                   [ 98%]
services/core/PlatformDriverAgent/tests/test_home_assistant.py::TestCoverMocked::test_scrape_all_cover_closing PASSED                                                                                   [100%]

============================================================================================== warnings summary ===============================================================================================
env/lib/python3.12/site-packages/pytz/tzinfo.py:27
  /home/xuwang/volttron/env/lib/python3.12/site-packages/pytz/tzinfo.py:27: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    _epoch = datetime.utcfromtimestamp(0)

env/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /home/xuwang/volttron/env/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 59 passed, 57 deselected, 2 warnings in 0.03s ================================================================================
```

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
